### PR TITLE
Fixes #359

### DIFF
--- a/src/lib/picker/ngx-emoji/emoji.service.ts
+++ b/src/lib/picker/ngx-emoji/emoji.service.ts
@@ -13,7 +13,7 @@ const SKINS = ['1F3FA', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF'];
 export const DEFAULT_BACKGROUNDFN = (
   set: string,
   sheetSize: number,
-) => `https://unpkg.com/emoji-datasource-${set}@5.0.1/img/${set}/sheets-256/${sheetSize}.png`;
+) => `https://unpkg.com/emoji-datasource-${set}@6.0.0/img/${set}/sheets-256/${sheetSize}.png`;
 
 @Injectable({ providedIn: 'root' })
 export class EmojiService {


### PR DESCRIPTION
Complete updating the default version of `EmojiService.emojiSpriteStyles` to match emoji data version 6. (See incomplete update here: https://github.com/scttcper/ngx-emoji-mart/commit/b0e194d9f9c20100ba0e949a623be0d27774cb36#diff-d28933681833eb18cf7a43760bc174939857e97dd20ba4c6dec6d0acbdf4a5eaR146)