### PR TITLE
fix: invoke the `handleScroll` safely

### DIFF
--- a/src/lib/picker/picker.component.ts
+++ b/src/lib/picker/picker.component.ts
@@ -336,8 +336,8 @@ export class PickerComponent implements OnInit {
       } else {
         // scrolling
         for (const category of this.categories) {
-          const component = this.categoryRefs.find(n => n.id === category.id);
-          const active = component!.handleScroll(target.scrollTop);
+          const component = this.categoryRefs.find(({ id }) => id === category.id);
+          const active: boolean | undefined = component?.handleScroll(target.scrollTop);
           if (active) {
             activeCategory = category;
           }


### PR DESCRIPTION
![error](https://user-images.githubusercontent.com/7337691/106345278-aadbc980-62b7-11eb-9430-e42acfed5287.png)
