### PR TITLE
feat: allow lazy loading emoji data

### DIFF
--- a/scripts/build-data.ts
+++ b/scripts/build-data.ts
@@ -201,11 +201,11 @@ const sEmojis = stringifyObject(emojis, {
   inlineCharacterLimit: 25,
   indent: '  '
 });
-let doc = `import { CompressedEmojiData } from './data.interfaces';
+let doc = `import type { CompressedEmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 export const emojis: CompressedEmojiData[] = ${sEmojis};
 `;
 fs.writeFileSync(
-  path.join(__dirname, '../src/lib/picker/ngx-emoji/data/emojis.ts'),
+  path.join(__dirname, '../src/lib/picker/emojis/emojis.ts'),
   doc
 );
 
@@ -213,11 +213,11 @@ const sCategories = stringifyObject(categories, {
   inlineCharacterLimit: 25,
   indent: '  '
 });
-doc = `import { EmojiCategory } from './data.interfaces';
+doc = `import type { EmojiCategory } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 export const categories: EmojiCategory[] = ${sCategories};
 `;
 fs.writeFileSync(
-  path.join(__dirname, '../src/lib/picker/ngx-emoji/data/categories.ts'),
+  path.join(__dirname, '../src/lib/picker/emojis/categories.ts'),
   doc
 );
 
@@ -225,11 +225,11 @@ const sSkins = stringifyObject(skins, {
   inlineCharacterLimit: 25,
   indent: '  '
 });
-doc = `import { SkinData } from './data.interfaces';
+doc = `import type { SkinData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 export const skins: SkinData[] = ${sSkins};
 `;
 fs.writeFileSync(
-  path.join(__dirname, '../src/lib/picker/ngx-emoji/data/skins.ts'),
+  path.join(__dirname, '../src/lib/picker/emojis/skins.ts'),
   doc
 );
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,9 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { GhButtonModule } from '@ctrl/ngx-github-buttons';
+import { EmojiLoaderModule } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+import { categories, emojis, skins } from '@ctrl/ngx-emoji-mart/emojis';
 
 import { PickerModule } from '../lib/picker/picker.module';
 import { AppComponent } from './app.component';
@@ -9,7 +12,15 @@ import { FooterComponent } from './footer.component';
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [PickerModule, GhButtonModule],
+      imports: [
+        PickerModule,
+        GhButtonModule,
+        EmojiLoaderModule.forRoot({
+          skins: () => of(skins),
+          emojis: () => of(emojis),
+          categories: () => of(categories),
+        }),
+      ],
       declarations: [AppComponent, FooterComponent],
     }).compileComponents();
   }));

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,10 +3,12 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { GhButtonModule } from '@ctrl/ngx-github-buttons';
 
-import { EmojiModule } from '../lib/picker/ngx-emoji/emoji.module';
-import { PickerModule } from '../lib/picker/picker.module';
+import { PickerModule } from '@ctrl/ngx-emoji-mart';
+import { EmojiModule, EmojiLoaderModule } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+
 import { AppComponent } from './app.component';
 import { FooterComponent } from './footer.component';
+import { from, map } from 'rxjs';
 
 @NgModule({
   declarations: [AppComponent, FooterComponent],
@@ -16,6 +18,11 @@ import { FooterComponent } from './footer.component';
     PickerModule,
     EmojiModule,
     GhButtonModule,
+    EmojiLoaderModule.forRoot({
+      skins: () => from(import('@ctrl/ngx-emoji-mart/emojis')).pipe(map(m => m.skins)),
+      emojis: () => from(import('@ctrl/ngx-emoji-mart/emojis')).pipe(map(m => m.emojis)),
+      categories: () => from(import('@ctrl/ngx-emoji-mart/emojis')).pipe(map(m => m.categories)),
+    }),
   ],
   bootstrap: [AppComponent],
 })

--- a/src/lib/picker/emoji-frequency.service.spec.ts
+++ b/src/lib/picker/emoji-frequency.service.spec.ts
@@ -1,43 +1,45 @@
 import { inject, TestBed, waitForAsync } from '@angular/core/testing';
+import { of } from 'rxjs';
 
-import { EmojiService } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+import { EmojiService, EmojiLoaderModule } from './ngx-emoji';
+import { categories, emojis, skins } from './emojis';
 import { EmojiFrequentlyService } from './emoji-frequently.service';
 
 describe('EmojiFrequently', () => {
-  beforeEach(
-    waitForAsync(() => {
-      localStorage.clear();
-      TestBed.configureTestingModule({}).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      imports: [
+        EmojiLoaderModule.forRoot({
+          skins: () => of(skins),
+          emojis: () => of(emojis),
+          categories: () => of(categories),
+        }),
+      ],
+    }).compileComponents();
+  }));
 
-  it(
-    'should get default',
-    inject([EmojiFrequentlyService], (ef: EmojiFrequentlyService) => {
-      const defaults = ef.get(ef.DEFAULTS.length, 4);
-      expect(defaults.length).toEqual(ef.DEFAULTS.length);
-    }),
-  );
+  it('should get default', inject([EmojiFrequentlyService], (ef: EmojiFrequentlyService) => {
+    const defaults = ef.get(ef.DEFAULTS.length, 4);
+    expect(defaults.length).toEqual(ef.DEFAULTS.length);
+  }));
 
-  it(
-    'should get shorter default',
-    inject([EmojiFrequentlyService], (ef: EmojiFrequentlyService) => {
+  it('should get shorter default', inject(
+    [EmojiFrequentlyService],
+    (ef: EmojiFrequentlyService) => {
       const defaults = ef.get(8, 4);
       expect(defaults.length).toEqual(8);
-    }),
-  );
+    },
+  ));
 
-  it(
-    'should add emoji',
-    inject(
-      [EmojiFrequentlyService, EmojiService],
-      (ef: EmojiFrequentlyService, es: EmojiService) => {
-        const pineapple = es.getData('pineapple');
-        ef.get(8, 4);
-        ef.add(pineapple!);
-        const result = ef.get(8, 4);
-        expect(result.length).toEqual(9);
-      },
-    ),
-  );
+  it('should add emoji', inject(
+    [EmojiFrequentlyService, EmojiService],
+    (ef: EmojiFrequentlyService, es: EmojiService) => {
+      const pineapple = es.getData('pineapple');
+      ef.get(8, 4);
+      ef.add(pineapple!);
+      const result = ef.get(8, 4);
+      expect(result.length).toEqual(9);
+    },
+  ));
 });

--- a/src/lib/picker/emoji-search.service.ts
+++ b/src/lib/picker/emoji-search.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-import { categories, EmojiData, EmojiService } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+import { EmojiData, EmojiService, EmojiLoaderService } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+
 import { intersect } from './utils';
 
 @Injectable({ providedIn: 'root' })
@@ -15,7 +18,7 @@ export class EmojiSearch {
   emoticonsList: { [key: string]: string } = {};
   emojiSearch: { [key: string]: string } = {};
 
-  constructor(private emojiService: EmojiService) {
+  constructor(private emojiService: EmojiService, private emojiLoaderService: EmojiLoaderService) {
     for (const emojiData of this.emojiService.emojis) {
       const { shortNames, emoticons } = emojiData;
       const id = shortNames[0];
@@ -44,6 +47,11 @@ export class EmojiSearch {
     }
   }
 
+  /**
+   * This returns an observable since it calls `getCategories()`, which might be
+   * loaded asynchronously. If the user passes an observable that emits synchronously,
+   * then `search()` will also emit synchronously.
+   */
   search(
     value: string,
     emojisToShowFilter?: (x: any) => boolean,
@@ -51,145 +59,151 @@ export class EmojiSearch {
     include: any[] = [],
     exclude: any[] = [],
     custom: any[] = [],
-  ): EmojiData[] | null {
-    this.addCustomToPool(custom, this.originalPool);
+  ): Observable<EmojiData[] | null> {
+    return this.emojiLoaderService.getCategories().pipe(
+      map(categories => {
+        this.addCustomToPool(custom, this.originalPool);
 
-    let results: EmojiData[] | undefined;
-    let pool = this.originalPool;
+        let results: EmojiData[] | undefined;
+        let pool = this.originalPool;
 
-    if (value.length) {
-      if (value === '-' || value === '-1') {
-        return [this.emojisList['-1']];
-      }
-      if (value === '+' || value === '+1') {
-        return [this.emojisList['+1']];
-      }
-
-      let values = value.toLowerCase().split(/[\s|,|\-|_]+/);
-      let allResults = [];
-
-      if (values.length > 2) {
-        values = [values[0], values[1]];
-      }
-
-      if (include.length || exclude.length) {
-        pool = {};
-
-        for (const category of categories || []) {
-          const isIncluded = include && include.length ? include.indexOf(category.id) > -1 : true;
-          const isExcluded = exclude && exclude.length ? exclude.indexOf(category.id) > -1 : false;
-
-          if (!isIncluded || isExcluded) {
-            continue;
+        if (value.length) {
+          if (value === '-' || value === '-1') {
+            return [this.emojisList['-1']];
+          }
+          if (value === '+' || value === '+1') {
+            return [this.emojisList['+1']];
           }
 
-          for (const emojiId of category.emojis || []) {
-            // Need to make sure that pool gets keyed
-            // with the correct id, which is why we call emojiService.getData below
-            const emoji = this.emojiService.getData(emojiId);
-            pool[emoji?.id ?? ''] = emoji;
+          let values = value.toLowerCase().split(/[\s|,|\-|_]+/);
+          let allResults = [];
+
+          if (values.length > 2) {
+            values = [values[0], values[1]];
           }
-        }
 
-        if (custom.length) {
-          const customIsIncluded =
-            include && include.length ? include.indexOf('custom') > -1 : true;
-          const customIsExcluded =
-            exclude && exclude.length ? exclude.indexOf('custom') > -1 : false;
-          if (customIsIncluded && !customIsExcluded) {
-            this.addCustomToPool(custom, pool);
-          }
-        }
-      }
+          if (include.length || exclude.length) {
+            pool = {};
 
-      allResults = values
-        .map(v => {
-          let aPool = pool;
-          let aIndex = this.index;
-          let length = 0;
+            for (const category of categories || []) {
+              const isIncluded =
+                include && include.length ? include.indexOf(category.id) > -1 : true;
+              const isExcluded =
+                exclude && exclude.length ? exclude.indexOf(category.id) > -1 : false;
 
-          // eslint-disable-next-line @typescript-eslint/prefer-for-of
-          for (let charIndex = 0; charIndex < v.length; charIndex++) {
-            const char = v[charIndex];
-            length++;
-            if (!aIndex[char]) {
-              aIndex[char] = {};
-            }
-            aIndex = aIndex[char];
-
-            if (!aIndex.results) {
-              const scores: { [key: string]: number } = {};
-
-              aIndex.results = [];
-              aIndex.pool = {};
-
-              for (const id of Object.keys(aPool)) {
-                const emoji = aPool[id];
-                if (!this.emojiSearch[id]) {
-                  this.emojiSearch[id] = this.buildSearch(
-                    emoji.short_names,
-                    emoji.name,
-                    emoji.id,
-                    emoji.keywords,
-                    emoji.emoticons,
-                  );
-                }
-                const query = this.emojiSearch[id];
-                const sub = v.substr(0, length);
-                const subIndex = query.indexOf(sub);
-
-                if (subIndex !== -1) {
-                  let score = subIndex + 1;
-                  if (sub === id) {
-                    score = 0;
-                  }
-
-                  aIndex.results.push(this.emojisList[id]);
-                  aIndex.pool[id] = emoji;
-
-                  scores[id] = score;
-                }
+              if (!isIncluded || isExcluded) {
+                continue;
               }
 
-              aIndex.results.sort((a, b) => {
-                const aScore = scores[a.id];
-                const bScore = scores[b.id];
-
-                return aScore - bScore;
-              });
+              for (const emojiId of category.emojis || []) {
+                // Need to make sure that pool gets keyed
+                // with the correct id, which is why we call emojiService.getData below
+                const emoji = this.emojiService.getData(emojiId);
+                pool[emoji?.id ?? ''] = emoji;
+              }
             }
 
-            aPool = aIndex.pool;
+            if (custom.length) {
+              const customIsIncluded =
+                include && include.length ? include.indexOf('custom') > -1 : true;
+              const customIsExcluded =
+                exclude && exclude.length ? exclude.indexOf('custom') > -1 : false;
+              if (customIsIncluded && !customIsExcluded) {
+                this.addCustomToPool(custom, pool);
+              }
+            }
           }
 
-          return aIndex.results;
-        })
-        .filter(a => a);
+          allResults = values
+            .map(v => {
+              let aPool = pool;
+              let aIndex = this.index;
+              let length = 0;
 
-      if (allResults.length > 1) {
-        results = intersect.apply(null, allResults as any);
-      } else if (allResults.length) {
-        results = allResults[0];
-      } else {
-        results = [];
-      }
-    }
+              // eslint-disable-next-line @typescript-eslint/prefer-for-of
+              for (let charIndex = 0; charIndex < v.length; charIndex++) {
+                const char = v[charIndex];
+                length++;
+                if (!aIndex[char]) {
+                  aIndex[char] = {};
+                }
+                aIndex = aIndex[char];
 
-    if (results) {
-      if (emojisToShowFilter) {
-        results = results.filter((result: EmojiData) => {
-          if (result && result.id) {
-            return emojisToShowFilter(this.emojiService.names[result.id]);
+                if (!aIndex.results) {
+                  const scores: { [key: string]: number } = {};
+
+                  aIndex.results = [];
+                  aIndex.pool = {};
+
+                  for (const id of Object.keys(aPool)) {
+                    const emoji = aPool[id];
+                    if (!this.emojiSearch[id]) {
+                      this.emojiSearch[id] = this.buildSearch(
+                        emoji.short_names,
+                        emoji.name,
+                        emoji.id,
+                        emoji.keywords,
+                        emoji.emoticons,
+                      );
+                    }
+                    const query = this.emojiSearch[id];
+                    const sub = v.substr(0, length);
+                    const subIndex = query.indexOf(sub);
+
+                    if (subIndex !== -1) {
+                      let score = subIndex + 1;
+                      if (sub === id) {
+                        score = 0;
+                      }
+
+                      aIndex.results.push(this.emojisList[id]);
+                      aIndex.pool[id] = emoji;
+
+                      scores[id] = score;
+                    }
+                  }
+
+                  aIndex.results.sort((a, b) => {
+                    const aScore = scores[a.id];
+                    const bScore = scores[b.id];
+
+                    return aScore - bScore;
+                  });
+                }
+
+                aPool = aIndex.pool;
+              }
+
+              return aIndex.results;
+            })
+            .filter(a => a);
+
+          if (allResults.length > 1) {
+            results = intersect.apply(null, allResults as any);
+          } else if (allResults.length) {
+            results = allResults[0];
+          } else {
+            results = [];
           }
-          return false;
-        });
-      }
+        }
 
-      if (results && results.length > maxResults) {
-        results = results.slice(0, maxResults);
-      }
-    }
-    return results || null;
+        if (results) {
+          if (emojisToShowFilter) {
+            results = results.filter((result: EmojiData) => {
+              if (result && result.id) {
+                return emojisToShowFilter(this.emojiService.names[result.id]);
+              }
+              return false;
+            });
+          }
+
+          if (results && results.length > maxResults) {
+            results = results.slice(0, maxResults);
+          }
+        }
+        return results || null;
+      }),
+    );
   }
 
   buildSearch(
@@ -198,7 +212,7 @@ export class EmojiSearch {
     id: string,
     keywords: string[],
     emoticons: string[],
-  ) {
+  ): string {
     const search: string[] = [];
 
     const addToSearch = (strings: string | string[], split: boolean) => {

--- a/src/lib/picker/emojis/categories.ts
+++ b/src/lib/picker/emojis/categories.ts
@@ -1,4 +1,4 @@
-import { EmojiCategory } from './data.interfaces';
+import type { EmojiCategory } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 export const categories: EmojiCategory[] = [
   {
     id: 'people',

--- a/src/lib/picker/emojis/emojis.ts
+++ b/src/lib/picker/emojis/emojis.ts
@@ -1,4 +1,4 @@
-import { CompressedEmojiData } from './data.interfaces';
+import type { CompressedEmojiData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 export const emojis: CompressedEmojiData[] = [
   {
     name: 'Grinning Face',

--- a/src/lib/picker/emojis/index.ts
+++ b/src/lib/picker/emojis/index.ts
@@ -1,0 +1,3 @@
+export * from './emojis';
+export * from './skins';
+export * from './categories';

--- a/src/lib/picker/emojis/package.json
+++ b/src/lib/picker/emojis/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ctrl/ngx-emoji-mart/emojis",
+  "author": "scttcper",
+  "repository": "scttcper/ngx-emoji-mart",
+  "license": "MIT",
+  "ngPackage": {
+    "lib": {
+      "entryFile": "index.ts"
+    },
+    "dest": "../../../../dist/emojis"
+  }
+}

--- a/src/lib/picker/emojis/skins.ts
+++ b/src/lib/picker/emojis/skins.ts
@@ -1,33 +1,34 @@
-import { SkinData } from './data.interfaces';
+import type { SkinData } from '@ctrl/ngx-emoji-mart/ngx-emoji';
+
 export const skins: SkinData[] = [
   {
     name: 'Emoji Modifier Fitzpatrick Type-1-2',
     unified: '1F3FB',
     sheet: [11, 13],
-    shortName: 'skin-tone-2'
+    shortName: 'skin-tone-2',
   },
   {
     name: 'Emoji Modifier Fitzpatrick Type-3',
     unified: '1F3FC',
     sheet: [11, 14],
-    shortName: 'skin-tone-3'
+    shortName: 'skin-tone-3',
   },
   {
     name: 'Emoji Modifier Fitzpatrick Type-4',
     unified: '1F3FD',
     sheet: [11, 15],
-    shortName: 'skin-tone-4'
+    shortName: 'skin-tone-4',
   },
   {
     name: 'Emoji Modifier Fitzpatrick Type-5',
     unified: '1F3FE',
     sheet: [11, 16],
-    shortName: 'skin-tone-5'
+    shortName: 'skin-tone-5',
   },
   {
     name: 'Emoji Modifier Fitzpatrick Type-6',
     unified: '1F3FF',
     sheet: [11, 17],
-    shortName: 'skin-tone-6'
-  }
+    shortName: 'skin-tone-6',
+  },
 ];

--- a/src/lib/picker/ngx-emoji/index.ts
+++ b/src/lib/picker/ngx-emoji/index.ts
@@ -1,7 +1,6 @@
-export * from './data/categories';
 export * from './data/data.interfaces';
-export * from './data/emojis';
-export * from './data/skins';
+
+export * from './loader';
 
 export * from './emoji.component';
 export * from './emoji.module';

--- a/src/lib/picker/ngx-emoji/loader/emoji-loader.module.ts
+++ b/src/lib/picker/ngx-emoji/loader/emoji-loader.module.ts
@@ -1,0 +1,14 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+
+import { EmojiLoaderService } from './emoji-loader.service';
+import { EmojiLoaderOptions, EMOJI_LOADER_OPTIONS } from './symbols';
+
+@NgModule()
+export class EmojiLoaderModule {
+  static forRoot(options: EmojiLoaderOptions): ModuleWithProviders<EmojiLoaderModule> {
+    return {
+      ngModule: EmojiLoaderModule,
+      providers: [EmojiLoaderService, { provide: EMOJI_LOADER_OPTIONS, useValue: options }],
+    };
+  }
+}

--- a/src/lib/picker/ngx-emoji/loader/emoji-loader.service.ts
+++ b/src/lib/picker/ngx-emoji/loader/emoji-loader.service.ts
@@ -1,0 +1,50 @@
+import { Inject, Injectable, OnDestroy } from '@angular/core';
+import { defer, forkJoin, map, Observable, shareReplay, Subject, takeUntil } from 'rxjs';
+
+import { SkinData, EmojiCategory, CompressedEmojiData } from '../data/data.interfaces';
+
+import { EmojiLoaderOptions, EMOJI_LOADER_OPTIONS } from './symbols';
+
+@Injectable()
+export class EmojiLoaderService implements OnDestroy {
+  private data$ = defer(() =>
+    forkJoin([this.options.skins(), this.options.emojis(), this.options.categories()]),
+  ).pipe(
+    map(([skins, emojis, categories]) => ({ skins, emojis, categories })),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  private requestedToLoad = false;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(@Inject(EMOJI_LOADER_OPTIONS) private options: EmojiLoaderOptions) {}
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+  }
+
+  requestToLoad(): void {
+    if (this.requestedToLoad) {
+      return;
+    }
+
+    this.requestedToLoad = true;
+
+    // Note: we explicitly subscribe here to trigger the data loading. We don't need to pass any
+    // `next` handler since we only want to start data loading and its caching further.
+    this.data$.pipe(takeUntil(this.destroy$)).subscribe();
+  }
+
+  getSkins(): Observable<SkinData[]> {
+    return this.data$.pipe(map(({ skins }) => skins));
+  }
+
+  getEmojis(): Observable<CompressedEmojiData[]> {
+    return this.data$.pipe(map(({ emojis }) => emojis));
+  }
+
+  getCategories(): Observable<EmojiCategory[]> {
+    return this.data$.pipe(map(({ categories }) => categories));
+  }
+}

--- a/src/lib/picker/ngx-emoji/loader/index.ts
+++ b/src/lib/picker/ngx-emoji/loader/index.ts
@@ -1,0 +1,2 @@
+export * from './emoji-loader.module';
+export * from './emoji-loader.service';

--- a/src/lib/picker/ngx-emoji/loader/symbols.ts
+++ b/src/lib/picker/ngx-emoji/loader/symbols.ts
@@ -1,0 +1,12 @@
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import type { SkinData, EmojiCategory, CompressedEmojiData } from '../data/data.interfaces';
+
+export interface EmojiLoaderOptions {
+  emojis: () => Observable<CompressedEmojiData[]>;
+  categories: () => Observable<EmojiCategory[]>;
+  skins: () => Observable<SkinData[]>;
+}
+
+export const EMOJI_LOADER_OPTIONS = new InjectionToken('EmojiLoaderOptions');

--- a/src/lib/picker/picker.component.spec.ts
+++ b/src/lib/picker/picker.component.spec.ts
@@ -1,5 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { of } from 'rxjs';
 
+import { categories, emojis, skins } from './emojis';
+import { EmojiLoaderModule } from './ngx-emoji';
 import { PickerComponent } from './picker.component';
 import { PickerModule } from './picker.module';
 
@@ -9,9 +12,15 @@ describe('PickerComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [PickerModule],
-    })
-    .compileComponents();
+      imports: [
+        PickerModule,
+        EmojiLoaderModule.forRoot({
+          skins: () => of(skins),
+          emojis: () => of(emojis),
+          categories: () => of(categories),
+        }),
+      ],
+    }).compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/lib/picker/picker.css
+++ b/src/lib/picker/picker.css
@@ -22,6 +22,7 @@
   border: 0 solid #d9d9d9;
 }
 .emoji-mart-bar:first-child {
+  height: 43px;
   border-bottom-width: 1px;
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;

--- a/src/lib/picker/search.component.ts
+++ b/src/lib/picker/search.component.ts
@@ -103,15 +103,18 @@ export class SearchComponent implements AfterViewInit, OnInit {
       this.icon = this.icons.delete;
       this.isSearching = true;
     }
-    const emojis = this.emojiSearch.search(
-      this.query,
-      this.emojisToShowFilter,
-      this.maxResults,
-      this.include,
-      this.exclude,
-      this.custom,
-    ) as any[];
-    this.searchResults.emit(emojis);
+    this.emojiSearch
+      .search(
+        this.query,
+        this.emojisToShowFilter,
+        this.maxResults,
+        this.include,
+        this.exclude,
+        this.custom,
+      )
+      .subscribe(emojis => {
+        this.searchResults.emit(emojis as any[]);
+      });
   }
   handleChange() {
     this.handleSearch(this.query);

--- a/src/lib/picker/skins.component.ts
+++ b/src/lib/picker/skins.component.ts
@@ -1,20 +1,11 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { Emoji } from '@ctrl/ngx-emoji-mart/ngx-emoji';
 
 @Component({
   selector: 'emoji-skins',
   template: `
-    <section
-      class="emoji-mart-skin-swatches"
-      [class.opened]="opened"
-    >
+    <section class="emoji-mart-skin-swatches" [class.opened]="opened">
       <span
         *ngFor="let skinTone of skinTones"
         class="emoji-mart-skin-swatch"
@@ -31,8 +22,8 @@ import { Emoji } from '@ctrl/ngx-emoji-mart/ngx-emoji';
           [attr.aria-pressed]="pressed(skinTone)"
           [attr.aria-haspopup]="!!isSelected(skinTone)"
           [attr.aria-expanded]="expanded(skinTone)"
-          [attr.aria-label]="i18n.skintones[skinTone]"
-          [title]="i18n.skintones[skinTone]"
+          [attr.aria-label]="i18n.skintones?.[skinTone]"
+          [title]="i18n.skintones?.[skinTone]"
         ></span>
       </span>
     </section>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
       "dom"
     ],
     "paths": {
+      "@ctrl/ngx-emoji-mart": ["./src/lib/picker/public_api"],
+      "@ctrl/ngx-emoji-mart/emojis": ["./src/lib/picker/emojis/index"],
       "@ctrl/ngx-emoji-mart/ngx-emoji": ["./src/lib/picker/ngx-emoji/index"]
     }
   },


### PR DESCRIPTION
Hey @scttcper 

I'll leave this PR in draft so we can discuss further steps and if the change is worth releasing.

I've added an ability to add a loader for emojis, categories and skins; thus they can be loaded synchronously or asynchronously (through the dynamic import, HTTP, etc.).

This PR contains breaking changes so if we'll proceed with merging I'll update the readme and it'll require a major bump.

I'm gonna leave notes on what I've done:

- `data.interfaces.ts` has been moved to `@ctrl/ngx-emoji-mart/types`, so all interfaces are decoupled from the code and can be re-used
- I've moved `emojis.ts`, `categories.ts` and `skins.ts` to `@ctrl/ngx-emoji-mart/emojis`
- I've added `@ctrl/ngx-emoji-mart/loader` which serves as a provider for data
- the data is loaded once the first picker component is created and cached (so subsequent observable emittions will be synchronous)

You can checkout the branch locally and test it in the example app since you know the functionality best. You can find any pitfalls with this approach.